### PR TITLE
Fix VR driver installation

### DIFF
--- a/windows/web/slimevr_web_installer.nsi
+++ b/windows/web/slimevr_web_installer.nsi
@@ -282,15 +282,17 @@ Section
     DetailPrint "Copying SlimeVR Driver to SteamVR..."
     ${If} $steamVrDirectory == ""
         ${DisableX64FSRedirection}
-        nsExec::Exec "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -File $\"$INSTDIR\steamvr.ps1$\" -SteamPath $\"$SteamPath$\" -DriverPath $\"$TEMP\slimevr-openvr-driver-win64\slimevr$\"" $0
+        nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "$INSTDIR\steamvr.ps1" -SteamPath "$SteamPath" -DriverPath "$TEMP\slimevr-openvr-driver-win64\slimevr"' $0
         ${EnableX64FSRedirection}
         Pop $0
+        Pop $1
         ${If} $0 != 0
             ${If} $hasExistingInstall == ""
                 Call cleanInstDir
             ${Endif}
             Abort "Failed to copy SlimeVR Driver. Make sure you have SteamVR installed."
         ${EndIf}
+        DetailPrint $1
     ${Else}
         CopyFiles /SILENT "$TEMP\slimevr-openvr-driver-win64\slimevr" "$steamVrDirectory\drivers"
     ${Endif}
@@ -331,9 +333,11 @@ SectionEnd
 # Uninstaller section start
 Section "uninstall"
     ${DisableX64FSRedirection}
-    nsExec::Exec "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -File $\"$INSTDIR\steamvr.ps1$\" -SteamPath $\"$SteamPath$\" -DriverPath $\"slimevr$\" -Uninstall" $0
+    nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "$INSTDIR\steamvr.ps1" -SteamPath "$SteamPath" -DriverPath "slimevr" -Uninstall"' $0
     ${EnableX64FSRedirection}
     Pop $0
+    Pop $1
+    DetailPrint $1
 
     # Remove the shortcuts
     RMdir /r "$SMPROGRAMS\SlimeVR Server"

--- a/windows/web/steamvr.ps1
+++ b/windows/web/steamvr.ps1
@@ -11,6 +11,7 @@ $ExternalDriverPaths = @()
 if ($OpenVrConfig.external_drivers.Length) {
     foreach ($ExternalDriverPath in $OpenVrConfig.external_drivers) {
         if (-not (Test-Path -Path "$ExternalDriverPath\driver.vrdrivermanifest")) {
+            $ExternalDriverPaths += $ExternalDriverPath
             continue
         }
         $DriverManifest = Get-Content -Path "$ExternalDriverPath\driver.vrdrivermanifest" | ConvertFrom-Json

--- a/windows/web/steamvr.ps1
+++ b/windows/web/steamvr.ps1
@@ -7,23 +7,23 @@ param (
 
 # Prune external SlimeVR driver(s) and possibly invalid entries
 $OpenVrConfig = Get-Content -Path "$env:LOCALAPPDATA\openvr\openvrpaths.vrpath" | ConvertFrom-Json
-$DriverPaths = @()
+$ExternalDriverPaths = @()
 if ($OpenVrConfig.external_drivers.Length) {
-    foreach ($DriverPath in $OpenVrConfig.external_drivers) {
-        if (-not (Test-Path -Path "$DriverPath\driver.vrdrivermanifest")) {
+    foreach ($ExternalDriverPath in $OpenVrConfig.external_drivers) {
+        if (-not (Test-Path -Path "$ExternalDriverPath\driver.vrdrivermanifest")) {
             continue
         }
-        $DriverManifest = Get-Content -Path "$DriverPath\driver.vrdrivermanifest" | ConvertFrom-Json
+        $DriverManifest = Get-Content -Path "$ExternalDriverPath\driver.vrdrivermanifest" | ConvertFrom-Json
         if ($DriverManifest.name -eq "SlimeVR") {
             continue
         }
-        $DriverPaths += $DriverPath
+        $ExternalDriverPaths += $ExternalDriverPath
     }
 }
-if ($DriverPaths.Length -eq 0) {
+if ($ExternalDriverPaths.Length -eq 0) {
     $OpenVrConfig.external_drivers = $null
 } else {
-    $OpenVrConfig.external_drivers = $DriverPaths
+    $OpenVrConfig.external_drivers = $ExternalDriverPaths
 }
 ConvertTo-Json -InputObject $OpenVrConfig | Out-File -FilePath "$env:LOCALAPPDATA\openvr\openvrpaths.vrpath"
 
@@ -33,10 +33,12 @@ $SteamVrPath = "$SteamPath\steamapps\common\SteamVR"
 if ((Test-Path -Path "$SteamVrPath\bin") -eq $true) {
     if ($Uninstall -eq $true) {
         Remove-Item -Recurse -Path "$SteamVrPath\drivers\$DriverFolder"
-        return
+        Write-Host "Deleted SlimeVR Driver from `"$SteamVrPath\drivers`""
+        exit 0
     }
     Copy-Item -Recurse -Force -Path $DriverPath -Destination "$SteamVrPath\drivers"
-    return
+    Write-Host "Copied SlimeVR Driver to `"$SteamVrPath\drivers`""
+    exit 0
 }
 
 # If not, try looking it up in defined library folders
@@ -47,10 +49,12 @@ foreach ($Match in $res.Matches) {
     if ((Test-Path -Path "$SteamVrPath\bin") -eq $true) {
         if ($Uninstall -eq $true) {
             Remove-Item -Recurse -Path "$SteamVrPath\drivers\$DriverFolder"
-            return
+            Write-Host "Deleted SlimeVR Driver from `"$SteamVrPath\drivers`""
+            exit 0
         }
         Copy-Item -Recurse -Force -Path $DriverPath -Destination "$SteamVrPath\drivers"
-        return
+        Write-Host "Copied SlimeVR Driver to `"$SteamVrPath\drivers`""
+        exit 0
     }
 }
 


### PR DESCRIPTION
* Output powershell script execution output
* Use single and double quotes for powershell script, instead of escapes
* Rename OpenVR-related variables to avoid overwriting global `$DriverPath` argument